### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Plugin to allow acme dns-01 authentication of a name managed in cPanel. Useful f
 ## Named Arguments
 | Argument | Description |
 | --- | --- |
-| --certbot-dns-cpanel:cpanel-credentials &lt;file&gt; | cPanel credentials INI file **(required)** |
-| --certbot-dns-cpanel:cpanel-propagation-seconds &lt;seconds&gt; | The number of seconds to wait for DNS to propagate before asking the ACME server to verify the DNS record (Default: 30) |
+| --cpanel-credentials &lt;file&gt; | cPanel credentials INI file **(required)** |
+| --cpanel-propagation-seconds &lt;seconds&gt; | The number of seconds to wait for DNS to propagate before asking the ACME server to verify the DNS record (Default: 30) |
 
 ## Install
 ``` bash
-pip install certbot-dns-cpanel
+pip install certbot-dns-cpanel --break-system-packages
 ```
 
 ## Credentials
@@ -18,13 +18,13 @@ Download the file `credentials.ini.example` and rename it to `credentials.ini`. 
 ```
 # The url cPanel url
 # include the scheme and the port number (usually 2083 for https)
-certbot_dns_cpanel:cpanel_url = https://cpanel.example.com:2083
+cpanel_url = https://cpanel.example.com:2083
 
 # The cPanel username
-certbot_dns_cpanel:cpanel_username = user
+cpanel_username = user
 
 # The cPanel password
-certbot_dns_cpanel:cpanel_password = hunter2
+cpanel_password = hunter2
 ```
 
 ## Example
@@ -32,8 +32,8 @@ You can now run certbot using the plugin and feeding the credentials file.
 For example, to get a wildcard certificate for *.example.com and example.com:
 ``` bash
 certbot certonly \
---authenticator certbot-dns-cpanel:cpanel \
---certbot-dns-cpanel:cpanel-credentials /path/to/credentials.ini \
+--authenticator cpanel \
+--cpanel-credentials /path/to/credentials.ini \
 -d 'example.com' \
 -d '*.example.com'
 ```
@@ -42,9 +42,9 @@ You can also specify a installer plugin with the `--installer` option:
 
 ``` bash
 certbot run \
---authenticator certbot-dns-cpanel:cpanel \
+--authenticator cpanel \
 --installer apache \
---certbot-dns-cpanel:cpanel-credentials /path/to/credentials.ini \
+--cpanel-credentials /path/to/credentials.ini \
 -d 'example.com' \
 -d '*.example.com'
 ```
@@ -53,9 +53,9 @@ You may also install the certificate onto a domain on your cPanel account:
 
 ```bash
 certbot run \
---authenticator certbot-dns-cpanel:cpanel \
---installer certbot-dns-cpanel:cpanel \
---certbot-dns-cpanel:cpanel-credentials /path/to/credentials.ini \
+--authenticator cpanel \
+--installer cpanel \
+--cpanel-credentials /path/to/credentials.ini \
 -d 'example.com' \
 -d '*.example.com'
 ```
@@ -70,8 +70,8 @@ docker run -it \
 -v /path/to/credentials.ini:/tmp/credentials.ini \
 badjware/certbot-dns-cpanel \
 certonly \
---authenticator certbot-dns-cpanel:cpanel \
---certbot-dns-cpanel:cpanel-credentials /tmp/credentials.ini \
+--authenticator cpanel \
+--cpanel-credentials /tmp/credentials.ini \
 -d 'example.com' \
 -d '*.example.com'
 ```


### PR DESCRIPTION
Since certbot 2.0, it uses only the plug-in name.
Since Debian Trixie, pip packages must use a virtual environment or use "--break-system-packages" flag to install system-wide.